### PR TITLE
Fix for issue #1, fatal error in customizer

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -119,7 +119,7 @@ function _s_backbone_scripts() {
 				'author_permastruct' => $wp_rewrite->get_author_permastruct(),
 				'host' => preg_replace( '#^http(s)?://#i', '', untrailingslashit( get_option( 'home' ) ) ),
 				'path' => _s_backbone_get_request_path(),
-				'use_trailing_slashes' => $wp_rewrite->use_trailing_s_backbonelashes,
+				'use_trailing_slashes' => $wp_rewrite->use_trailing_slashes,
 				'parameters' => _s_backbone_get_request_parameters(),
 			),
 		);

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -21,6 +21,6 @@ add_action( 'customize_register', '_s_backbone_customize_register' );
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
 function _s_backbone_customize_preview_js() {
-	wp_enqueue_s_backbonecript( '_s_backbone_customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), '20130508', true );
+	wp_enqueue_script( '_s_backbone_customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), '20130508', true );
 }
 add_action( 'customize_preview_init', '_s_backbone_customize_preview_js' );


### PR DESCRIPTION
Looks like some functions accidentally got an '_backbone' inserted into them during find/replace. Props to @boborchard for reporting this. Pull request fixes #1
