### PR TITLE
pass the current paged var to the localized settings var

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -133,6 +133,11 @@ function _s_backbone_scripts() {
 		} elseif ( is_author() ) {
 			$local['loopType'] = 'author';
 		}
+		
+		//set the page we're on so that Backbone can load the proper state
+		if ( is_paged() ) {
+			$local['page'] = get_query_var( 'paged' );
+		}
 
 		wp_localize_script( '_s_backbone-loop', 'settings', $local );
 	}

--- a/js/loop.js
+++ b/js/loop.js
@@ -23,7 +23,7 @@
 	var posts = new wp.api.collections.Posts();
 	var options = {
 		data: {
-			page: 2
+			page: settings.page || 2
 		}
 	};
 


### PR DESCRIPTION
@tlovett1 - let me know if this makes sense to add. for me, it resolves a bug I had where I'd load <site_url>/page/10/ (for example) and then it would pull page 2. NB: this doesn't exactly mimic the standard behavior where the Backbone initial sync pulls in page 2 when you're on page 1, so this might need some tweaking. It does, however, correctly go get ?page=11 when you hit 'More.'
